### PR TITLE
Dismantle code not used for our use case

### DIFF
--- a/node-rfc/run_rfc_task.js
+++ b/node-rfc/run_rfc_task.js
@@ -132,11 +132,8 @@ module.exports = function(grunt) {
     grunt.registerTask("uploadToABAP", "Uploads the application to the ABAP System", function(transportRequest) {
         grunt.log.writeln("Uploading to ABAP");
         if (!transportRequest) {
-            if (!fs.existsSync(ctsDataFile)) {
-                grunt.log.errorlns("No Transport request specified. Pass one explicitly or run createTransportRequest first.");
-                return (false);
-            }
-            transportRequest = JSON.parse(fs.readFileSync(ctsDataFile, { encoding: "utf8" })).REQUESTID;
+            grunt.log.errorlns("No Transport request specified.");
+            return (false);
         }
         grunt.log.writeln("Transport request:", transportRequest);
         var url = this.options().zipFileURL;
@@ -171,11 +168,8 @@ module.exports = function(grunt) {
     grunt.registerTask("releaseTransport", "Releases an ABAP Transport Request", function(transportRequest) {
         grunt.log.writeln("Releasing Transport Request");
         if (!transportRequest) {
-            if (!fs.existsSync(ctsDataFile)) {
-                grunt.log.errorlns("No Transport request specified. Pass one explicitly or run createTransportRequest first.");
-                return (false);
-            }
-            transportRequest = JSON.parse(fs.readFileSync(ctsDataFile, { encoding: "utf8" })).REQUESTID;
+            grunt.log.errorlns("No Transport request specified.");
+            return (false);
         }
         grunt.log.writeln("Transport request:", transportRequest);
         var importParameters = {


### PR DESCRIPTION
We never read the transport request id from file in our use cases.
We hand over the transport request id via signature. Hence it is - for our
use case - dead coding. There is no other known use case (at least to me).

Having dead code causes confusion ([two years later]: [Q] do you know if we)
need that code? [A] I don't know, most probably not, but who known. Let's keep
it ...

In case that use case gets important it can be added again.

Hence I vote for removing that code.

@radsoulbeard in case you know about other cases where we in fact hand over the transport request id via mouting a directory from outside into the docker container we should of course not merge this PR.