### PR TITLE
Improve check for return value for uploading content.

### DIFF
--- a/node-rfc/run_rfc_task.js
+++ b/node-rfc/run_rfc_task.js
@@ -160,9 +160,14 @@ module.exports = function(grunt) {
                     grunt.log.writeln("Return:", returnValue);
                     done(false);
                     return;
+                } else if (returnValue.EV_SUCCESS == 'S') {
+                    grunt.log.writeln("Application uploaded.");
+                    done();
+                } else {
+                    grunt.log.writeln("Invalid return status (EV_SUCCESS): " + returnValue.EV_SUCCESS);
+                    done(false);
+                    return;
                 }
-                grunt.log.writeln("Application uploaded.");
-                done();
             },
             function() {
                 done(false);


### PR DESCRIPTION
Up to now we checked only for "W" and "E", but there was no explicit
check for "S".

I checked in ABAP backend, these 3 values are the only supported values,
at least at the moment (status_succes, status_warning, status_error).

This should basically done also for creating and releasing a transport request. But before we do so we should have a closer look at the counter part in order to check for more return status codes.